### PR TITLE
Add serializer option to set tight list style on document level

### DIFF
--- a/src/to_markdown.js
+++ b/src/to_markdown.js
@@ -122,7 +122,13 @@ class MarkdownSerializerState {
     this.inTightList = false
     // :: Object
     // The options passed to the serializer.
+    //   tightLists:: ?bool
+    //   Whether to render lists in a tight style. This can be overridden
+    //   on a node level by specifying a tight attribute on the node.
+    //   Defaults to false.
     this.options = options || {}
+    if (typeof this.options.tightLists == "undefined")
+      this.options.tightLists = false
   }
 
   flushClose(size) {
@@ -275,10 +281,11 @@ class MarkdownSerializerState {
     else if (this.inTightList)
       this.flushClose(1)
 
+    let isTight = typeof node.attrs.tight != "undefined" ? node.attrs.tight : this.options.tightLists
     let prevTight = this.inTightList
-    this.inTightList = node.attrs.tight
+    this.inTightList = isTight
     node.forEach((child, _, i) => {
-      if (i && node.attrs.tight) this.flushClose(1)
+      if (i && isTight) this.flushClose(1)
       this.wrapBlock(delim, firstDelim(i), node, () => this.render(child, node, i))
     })
     this.inTightList = prevTight


### PR DESCRIPTION
Implemented as suggested in #4.

If the `tightLists` option is not set, I'm setting it to a default value directly on the options object. I'm not sure if we should create a defense copy of the object as we're modifying the argument that the user passes in. What do you think?
I also thought about only setting the specific options that the serializer supports, but I'm using additional options in my project, which the serializer does not know anything about. I am using these options inside my custom node rendering functions via `state.options`. Maybe this could be better solved by allowing an additional "user options" argument, which gets passed to the node rendering functions unmodified (either via the state instance or directly).