### PR TITLE
Expel trailing or leading whitespace from inside emphasis marks

### DIFF
--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -92,4 +92,9 @@ describe("markdown", () => {
 
   it("drops trailing hard breaks", () =>
      serialize(doc(p("a", br, br)), "a"))
+
+  it("expels enclosing whitespace from inside emphasis", () =>
+     serialize(doc(p("Some emphasized text with", strong(em("  whitespace   ")), "surrounding the emphasis.")),
+          "Some emphasized text with  ***whitespace***   surrounding the emphasis."))
+
 })


### PR DESCRIPTION
Per CommonMark (and the markdown-it implementation), syntax like
`* foo *` is not valid for emphasis. So when we encounter nodes
like `<em> foo </em>`, we now serialize them to ` *foo* `.

Fixes #1