### PR TITLE
Make sure serialize doesn't fail with line break inside inline mark

### DIFF
--- a/src/to_markdown.js
+++ b/src/to_markdown.js
@@ -232,7 +232,7 @@ export class MarkdownSerializerState {
         let info = this.marks[mark.type.name]
         return info && info.expelEnclosingWhitespace
       })) {
-        let [_, lead, inner, trail] = /^(\s*)(.*?)(\s*)$/.exec(node.text)
+        let [_, lead, inner, trail] = /^(\s*)(.*?)(\s*)$/m.exec(node.text)
         leading += lead
         trailing = trail
         if (lead || trail) {

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -90,6 +90,9 @@ describe("markdown", () => {
      same("1\\. foo",
           doc(p("1. foo"))))
 
+  it("doesn't fail with line break inside inline mark", () =>
+     same("**text1\ntext2**", doc(p(strong("text1\ntext2")))))
+
   it("drops trailing hard breaks", () =>
      serialize(doc(p("a", br, br)), "a"))
 


### PR DESCRIPTION
The spec here should be pretty self-explanatory. Before the change, it was crashing like this:

```
index.js:574 Uncaught TypeError: Cannot read property '1' of null
    at progress (index.js:574)
    at Fragment.forEach (index.js:242)
    at Node.forEach (index.js:1073)
    at MarkdownSerializerState.renderInline (index.js:635)
    at Object.paragraph (index.js:418)
    at MarkdownSerializerState.render (index.js:545)
    at index.js:553
    at Fragment.forEach (index.js:242)
    at Node.forEach (index.js:1073)
    at MarkdownSerializerState.renderContent (index.js:553)
    at MarkdownSerializer.serialize (index.js:372)
```

<img width="469" alt="client details for la - simplepractice 2018-04-17 19-23-28" src="https://user-images.githubusercontent.com/944286/38883165-d5bd0440-4274-11e8-9912-e7eafd889da8.png">
