### PR TITLE
Do not override user defined softbreak token handler

### DIFF
--- a/src/from_markdown.js
+++ b/src/from_markdown.js
@@ -145,7 +145,7 @@ function tokenHandlers(schema, tokens) {
 
   handlers.text = (state, tok) => state.addText(tok.content)
   handlers.inline = (state, tok) => state.parseTokens(tok.children)
-  handlers.softbreak = state => state.addText("\n")
+  handlers.softbreak = handlers.softbreak || (state => state.addText("\n"))
 
   return handlers
 }

--- a/test/test-custom-parser.js
+++ b/test/test-custom-parser.js
@@ -4,12 +4,13 @@ const ist = require("ist")
 const markdownit = require("markdown-it")
 const {schema, MarkdownParser} = require("../dist")
 
-const {doc, p} = require("./build")
+const {doc, p, hard_break} = require("./build")
 
 const md = markdownit("commonmark", {html: false})
 const ignoreBlockquoteParser = new MarkdownParser(schema, md, {
   blockquote: {ignore: true},
-  paragraph: {block: "paragraph"}
+  paragraph: {block: "paragraph"},
+  softbreak: {node: 'hard_break'}
 })
 
 function parseWith(parser) {
@@ -22,4 +23,8 @@ describe("custom markdown parser", () => {
   it("ignores a blockquote", () =>
      parseWith(ignoreBlockquoteParser)("> hello!",
           doc(p("hello!"))))
+
+  it("converts softbreaks to hard_break nodes", () =>
+    parseWith(ignoreBlockquoteParser)("hello\nworld!",
+         doc(p("hello", hard_break(), 'world!'))))
 })


### PR DESCRIPTION
Currently tokenHandles unconditionally override softbreak node handlers, meaning that if I add a rule for softbreaks to be replaced with something else it won't work because of that override. 