### PR TITLE
Only escape `*` at the start of a line.

### DIFF
--- a/src/to_markdown.js
+++ b/src/to_markdown.js
@@ -317,7 +317,7 @@ export class MarkdownSerializerState {
   // content. If `startOfLine` is true, also escape characters that
   // has special meaning only at the start of the line.
   esc(str, startOfLine) {
-    str = str.replace(/[`*\\~\[\]]/g, "\\$&")
+    str = str.replace(/[`\\~\[\]]/g, "\\$&")
     if (startOfLine) str = str.replace(/^[:#\-*+]/, "\\$&").replace(/^(\d+)\./, "$1\\.")
     return str
   }


### PR DESCRIPTION
Since introducing the prosemirror editor to Forestry.io, we have been super happy. There has been a few illusive bugs around the `*` character. This PR introduces the fix for those bugs

## Bug Fixed Examples

### When in Text Node contains an HTML Table
This was the troublesome case that brought this bug to our attention:

```json
{
  "type": "text",
  "text": "<table><tr><td>*test</td></tr></table>"
}
```

#### Output was:
```markdown
<table><tr><td>\*test</td></tr></table>
```
<table><tr><td>\*test</td></tr></table>

#### Output now:
```
<table><tr><td>*test</td></tr></table>
```
<table><tr><td>*test</td></tr></table>

### When marked up as `code`
```json
{
  "type": "text",
  "text": "*foo"
},
{
  "type": "text",
  "marks": [
    {
      "type": "code"
    }
  ],
  "text": "*"
}
```
#### Output was:
```markdown
\*foo`\*`
```
\*foo`\*`

#### Output now:
```
\*foo`*`
```
\*foo`*`

## Non-Regression Examples
The following examples are changes in output from prosemirror-markdown, but not changes in intended behaviour for the output site.

### Inside text node but after a new line
Prosemirror Node:
```json
{
  "type": "text",
  "text": "Test\n\***"
}
```

#### Output was:
```
Test
\*\*\*
```
Test
\*\*\*

#### Output Now:
```
Test
\***
```
Test
\***


### Bad Horizontal Rules
```json
{
  "type": "text",
  "text": "--*"
}
```
#### Output was:
```markdown
--\*
```
--\*
#### Output now:
```
--*
```
--*

## Problems with this solution

I believe this solution fixes more bugs then it creates. It does however create one bug for sure.

This is frustrating, but right now we think this is the more acceptable bug for Forestry.



### * at end of strong text
```json
{
  "type": "text",
  "marks": [
    {
      "type": "strong"
    }
  ],
  "text": "My Text *"
}
```

### Output was:

```markdown
**My Text \***
```
**My Text \***

### Output now:

```markdown
**My Text ***
```

**My Text ***

## Future Work

Along the lines of  #16, I think the ideal solution to the problems introduced by this PR would be to handle those edge cases by switching the opening and closing characters depending on the circumstance. 

For example: If the bold text starts or ends with `*` then use `__` instead.

I am currently trying to change our markdown tokens to work this way.
