### PR TITLE
Do not escape `\` when code mark is active

### DIFF
--- a/src/to_markdown.js
+++ b/src/to_markdown.js
@@ -96,7 +96,9 @@ export const defaultMarkdownSerializer = new MarkdownSerializer({
       }
   },
   text(state, node) {
-    state.text(node.text)
+    let marks = node ? node.marks : []
+    let code = marks.length && marks[marks.length - 1].type.isCode && marks[marks.length - 1]
+    state.text(node.text, !code)
   }
 }, {
   em: {open: "*", close: "*", mixable: true, expelEnclosingWhitespace: true},


### PR DESCRIPTION
In the Forestry.io  CMS we provide both a Prosemirror editor and a Codemirror editor for our users. You can switch back and forth at any time. This exposed a bug in the default text-token serializer. It runs `esc` even when those characters are inside `code` tags.

For example:

```
`te\st`
```
`te\st`

Would be come
```
`te\\st`
```
`te\\st`

![slashes](https://user-images.githubusercontent.com/824015/44233012-16c62800-a179-11e8-84ed-205687174b2b.gif)


Copied the code for determining if the `code` mark is applied from [here](https://github.com/ncphillips/prosemirror-markdown/blob/6b4d2201255f918e4922fade4bd81df7c9734a22/src/to_markdown.js#L242)

