### PR TITLE
Do not escape text when code mark applied

### DIFF
--- a/src/to_markdown.js
+++ b/src/to_markdown.js
@@ -96,7 +96,9 @@ export const defaultMarkdownSerializer = new MarkdownSerializer({
       }
   },
   text(state, node) {
-    state.text(node.text)
+    let marks = node.marks || []
+    let code = marks.find(mark => (mark.type.isCode))
+    state.text(node.text, !code)
   }
 }, {
   em: {open: "*", close: "*", mixable: true, expelEnclosingWhitespace: true},


### PR DESCRIPTION
Actually working solution of #24 