### PR TITLE
Special case hard breaks

### DIFF
--- a/src/to_markdown.js
+++ b/src/to_markdown.js
@@ -221,7 +221,17 @@ export class MarkdownSerializerState {
   renderInline(parent) {
     let active = [], trailing = ""
     let progress = (node, _, index) => {
-      let marks = node ? node.marks : []
+      let marks = []
+
+      // Remove `strong` and `em` marks from `hard_break` nodes to prevent
+      // parser edge cases with new lines just before closing marks.
+      if (node && node.type.name === "hard_break") {
+        for (let i = 0; i < node.marks.length; i++) {
+          let mark = node.marks[i]
+          if (["strong", "em"].indexOf(mark.type.name) === -1) marks.push(mark)
+        }
+      }
+      else if (node) marks = node.marks
 
       let leading = trailing
       trailing = ""

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -104,6 +104,18 @@ describe("markdown", () => {
      serialize(doc(p("Some emphasized text with", strong(em("  whitespace   ")), "surrounding the emphasis.")),
                "Some emphasized text with  ***whitespace***   surrounding the emphasis."))
 
+  it("puts trailing hard break out of emphasised content", () =>
+     serialize(doc(p("text1", strong(em("before break", br)), "text2")),
+               "text1***before break***\\\ntext2"))
+
+  it("splits emphasised content on surrounded hard break", () =>
+     serialize(doc(p("text1", strong(em("before break", br, "after break")), "text2")),
+               "text1***before break***\\\n***after break***text2"))
+
+  it("does not split links on surrounded hard break", () =>
+     serialize(doc(p(a("before break", br, "after break"))),
+               "[before break\\\nafter break](foo)"))
+
   it("drops nodes when all whitespace is expelled from them", () =>
      serialize(doc(p("Text with", em(" "), "an emphasized space")),
                "Text with an emphasized space"))


### PR DESCRIPTION
This improves an edge case of hard breaks ending a marked node. See https://discuss.prosemirror.net/t/position-of-hard-break-in-markdown-just-after-em-or-strong-node/1644

I opted in to only remove whitelisted `em` and `strong` marks from hard beaks as the behaviour now ist that a surrounded hard break now splits marked content into two parts, see the new tests. I find this ok for emphasised text, but not ok for links. The implementation could also be changed to check if the hard break actually is trailing, but I'm not sure if this is needed.

I did not use `Array.prototype.filter()` as I couldn't find its usage in any of the prose mirror repos.