### PR TITLE
Upgrade markdown-it to 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "prosemirror-model": "^1.0.0",
-    "markdown-it": "^8.4.2"
+    "markdown-it": "^10.0.0"
   },
   "devDependencies": {
     "ist": "1.0.0",


### PR DESCRIPTION
This bumps `markdown-it` to version ^10 to avoid the [ReDoS vulnerability found in older versions](https://snyk.io/vuln/SNYK-JS-MARKDOWNIT-459438). 