### PR TITLE
Improve ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "prosemirror-model": "^1.0.0",
-    "markdown-it": "^10.0.0"
+    "markdown-it-esm": "^10.0.0"
   },
   "devDependencies": {
     "ist": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "mocha": "^3.0.2",
     "prosemirror-test-builder": "^1.0.0",
     "punycode": "^1.4.0",
-    "rollup": "^0.49.0",
-    "rollup-plugin-buble": "^0.15.0",
+    "rollup": "^1.26.3",
+    "@rollup/plugin-buble": "^0.20.0",
     "builddocs": "^0.3.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.2",
   "description": "ProseMirror Markdown integration",
   "main": "dist/index.js",
+  "module": "src/index.js",
   "license": "MIT",
   "maintainers": [
     {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "prosemirror-model": "^1.0.0",
-    "markdown-it-esm": "^10.0.0"
+    "markdown-it": "^10.0.0"
   },
   "devDependencies": {
     "ist": "1.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,12 @@
-module.exports = {
-  input: "./src/index.js",
-  output: {format: "cjs", file: "dist/index.js"},
-  sourcemap: true,
-  plugins: [require("rollup-plugin-buble")()],
+import buble from '@rollup/plugin-buble'
+
+export default {
+  input: './src/index.js',
+  output: {
+    dir: 'dist',
+    format: 'cjs',
+    sourcemap: true
+  },
+  plugins: [buble()],
   external(id) { return !/^[\.\/]/.test(id) }
 }


### PR DESCRIPTION
I applied the usually changes with one difference.

ESM support is required for the markdown-it dependency.  I tried to submit a PR to the original repository but the main maintainer has a very strong opinion about what should be done:

https://github.com/markdown-it/markdown-it/pull/613

It is really unlikely _markdown-it_ will provide ESM support in the next few weeks or months. As a consequence I created a fork in prosemirror-esm organization:

https://github.com/prosemirror-esm/markdown-it/commits/markdown-it-esm

and published a version of the package on npmjs that includes an ESM variant generated by rollup.

@marijnh If you agree, I suggest using this version until an official support is provided.