### PR TITLE
Transpile module entry with buble

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.0",
   "description": "ProseMirror Markdown integration",
   "main": "dist/index.js",
-  "module": "src/index.js",
+  "module": "dist/module/index.js",
   "license": "MIT",
   "maintainers": [
     {
@@ -21,17 +21,18 @@
     "markdown-it": "^10.0.0"
   },
   "devDependencies": {
+    "@rollup/plugin-buble": "^0.20.0",
+    "buble": "^0.19.8",
+    "builddocs": "^0.3.0",
     "ist": "1.0.0",
     "mocha": "^3.0.2",
     "prosemirror-test-builder": "^1.0.0",
     "punycode": "^1.4.0",
-    "rollup": "^1.26.3",
-    "@rollup/plugin-buble": "^0.20.0",
-    "builddocs": "^0.3.0"
+    "rollup": "^1.26.3"
   },
   "scripts": {
     "test": "mocha test/test-*.js",
-    "build": "rollup -c",
+    "build": "rollup -c && buble src/ -o dist/module --no moduleImport,moduleExport",
     "watch": "rollup -c -w",
     "prepare": "npm run build",
     "build_readme": "builddocs --name markdown --format markdown --main src/README.md src/*.js > README.md"


### PR DESCRIPTION
The intention of this PR is to transpile the `module` entry via `buble` the same way the `main` bundle is. 

On our end the introduction of `module` caused issues with older browsers (namely IE) not supporting used ES2015, this fixes them.