### PR TITLE
New option for the block/mark to have noCloseToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ the tokens to create a ProseMirror document tree.
        appended to the base token name provides a the object
        property), and wraps a block of content. The block should be
        wrapped in a node of the type named to by the property's
-       value.
+       value. If the token does not have `_open` or `_close`, use the `noOpenClose` option.
 
    **`mark`**`: ?string`
      : This token also comes in `_open` and `_close` variants, but
@@ -72,6 +72,11 @@ the tokens to create a ProseMirror document tree.
        that takes a [markdown-it
        token](https://markdown-it.github.io/markdown-it/#Token) and
        returns an attribute object.
+
+   **`noOpenClose`**`: ?boolean`
+     : Indicates that the [markdown-it
+       token](https://markdown-it.github.io/markdown-it/#Token) has no `_open` or `_close` for the nodes.
+       This defaults to `true` for `code_inline`, `code_block` and `fence`.
 
    **`ignore`**`: ?bool`
      : When true, ignore content for the matched token.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ the tokens to create a ProseMirror document tree.
        appended to the base token name provides a the object
        property), and wraps a block of content. The block should be
        wrapped in a node of the type named to by the property's
-       value. If the token does not have `_open` or `_close`, use the `noOpenClose` option.
+       value. If the token does not have `_open` or `_close`, use
+       the `noCloseToken` option.
 
    **`mark`**`: ?string`
      : This token also comes in `_open` and `_close` variants, but
@@ -73,10 +74,11 @@ the tokens to create a ProseMirror document tree.
        token](https://markdown-it.github.io/markdown-it/#Token) and
        returns an attribute object.
 
-   **`noOpenClose`**`: ?boolean`
+   **`noCloseToken`**`: ?boolean`
      : Indicates that the [markdown-it
-       token](https://markdown-it.github.io/markdown-it/#Token) has no `_open` or `_close` for the nodes.
-       This defaults to `true` for `code_inline`, `code_block` and `fence`.
+       token](https://markdown-it.github.io/markdown-it/#Token) has
+       no `_open` or `_close` for the nodes. This defaults to `true`
+       for `code_inline`, `code_block` and `fence`.
 
    **`ignore`**`: ?bool`
      : When true, ignore content for the matched token.

--- a/src/from_markdown.js
+++ b/src/from_markdown.js
@@ -90,8 +90,8 @@ function attrs(spec, token) {
 
 // Code content is represented as a single token with a `content`
 // property in Markdown-it.
-function noOpenClose(spec, type) {
-  return spec.noOpenClose || type == "code_inline" || type == "code_block" || type == "fence"
+function noCloseToken(spec, type) {
+  return spec.noCloseToken || type == "code_inline" || type == "code_block" || type == "fence"
 }
 
 function withoutTrailingNewline(str) {
@@ -106,7 +106,7 @@ function tokenHandlers(schema, tokens) {
     let spec = tokens[type]
     if (spec.block) {
       let nodeType = schema.nodeType(spec.block)
-      if (noOpenClose(spec, type)) {
+      if (noCloseToken(spec, type)) {
         handlers[type] = (state, tok) => {
           state.openNode(nodeType, attrs(spec, tok))
           state.addText(withoutTrailingNewline(tok.content))
@@ -121,7 +121,7 @@ function tokenHandlers(schema, tokens) {
       handlers[type] = (state, tok) => state.addNode(nodeType, attrs(spec, tok))
     } else if (spec.mark) {
       let markType = schema.marks[spec.mark]
-      if (noOpenClose(spec, type)) {
+      if (noCloseToken(spec, type)) {
         handlers[type] = (state, tok) => {
           state.openMark(markType.create(attrs(spec, tok)))
           state.addText(withoutTrailingNewline(tok.content))
@@ -132,7 +132,7 @@ function tokenHandlers(schema, tokens) {
         handlers[type + "_close"] = state => state.closeMark(markType)
       }
     } else if (spec.ignore) {
-      if (noOpenClose(spec, type)) {
+      if (noCloseToken(spec, type)) {
         handlers[type] = noOp
       } else {
         handlers[type + '_open'] = noOp
@@ -190,6 +190,12 @@ export class MarkdownParser {
   //     token](https://markdown-it.github.io/markdown-it/#Token) and
   //     returns an attribute object.
   //
+  // ** `noCloseToken` ** `: ?boolean`
+  //   : Indicates that the[markdown-it
+  //     token](https://markdown-it.github.io/markdown-it/#Token) has no
+  //     `_open` or `_close` for the nodes. This defaults to `true`
+  //     for `code_inline`, `code_block` and `fence`.
+  //
   // **`ignore`**`: ?bool`
   //   : When true, ignore content for the matched token.
   constructor(schema, tokenizer, tokens) {
@@ -224,8 +230,8 @@ export const defaultMarkdownParser = new MarkdownParser(schema, markdownit("comm
   bullet_list: {block: "bullet_list"},
   ordered_list: {block: "ordered_list", getAttrs: tok => ({order: +tok.attrGet("start") || 1})},
   heading: {block: "heading", getAttrs: tok => ({level: +tok.tag.slice(1)})},
-  code_block: {block: "code_block", noOpenClose: true},
-  fence: {block: "code_block", getAttrs: tok => ({params: tok.info || ""}), noOpenClose: true},
+  code_block: {block: "code_block", noCloseToken: true},
+  fence: {block: "code_block", getAttrs: tok => ({params: tok.info || ""}), noCloseToken: true},
   hr: {node: "horizontal_rule"},
   image: {node: "image", getAttrs: tok => ({
     src: tok.attrGet("src"),
@@ -240,5 +246,5 @@ export const defaultMarkdownParser = new MarkdownParser(schema, markdownit("comm
     href: tok.attrGet("href"),
     title: tok.attrGet("title") || null
   })},
-  code_inline: {mark: "code", noOpenClose: true}
+  code_inline: {mark: "code", noCloseToken: true}
 })

--- a/src/from_markdown.js
+++ b/src/from_markdown.js
@@ -173,7 +173,8 @@ export class MarkdownParser {
   //     appended to the base token name provides a the object
   //     property), and wraps a block of content. The block should be
   //     wrapped in a node of the type named to by the property's
-  //     value.
+  //     value. If the token does not have `_open` or `_close`, use
+  //     the `noCloseToken` option.
   //
   // **`mark`**`: ?string`
   //   : This token also comes in `_open` and `_close` variants, but
@@ -190,10 +191,10 @@ export class MarkdownParser {
   //     token](https://markdown-it.github.io/markdown-it/#Token) and
   //     returns an attribute object.
   //
-  // ** `noCloseToken` ** `: ?boolean`
-  //   : Indicates that the[markdown-it
-  //     token](https://markdown-it.github.io/markdown-it/#Token) has no
-  //     `_open` or `_close` for the nodes. This defaults to `true`
+  // **`noCloseToken`**`: ?boolean`
+  //   : Indicates that the [markdown-it
+  //     token](https://markdown-it.github.io/markdown-it/#Token) has
+  //     no `_open` or `_close` for the nodes. This defaults to `true`
   //     for `code_inline`, `code_block` and `fence`.
   //
   // **`ignore`**`: ?bool`

--- a/src/from_markdown.js
+++ b/src/from_markdown.js
@@ -90,8 +90,8 @@ function attrs(spec, token) {
 
 // Code content is represented as a single token with a `content`
 // property in Markdown-it.
-function noOpenClose(type) {
-  return type == "code_inline" || type == "code_block" || type == "fence"
+function noOpenClose(spec, type) {
+  return spec.noOpenClose || type == "code_inline" || type == "code_block" || type == "fence"
 }
 
 function withoutTrailingNewline(str) {
@@ -106,7 +106,7 @@ function tokenHandlers(schema, tokens) {
     let spec = tokens[type]
     if (spec.block) {
       let nodeType = schema.nodeType(spec.block)
-      if (noOpenClose(type)) {
+      if (noOpenClose(spec, type)) {
         handlers[type] = (state, tok) => {
           state.openNode(nodeType, attrs(spec, tok))
           state.addText(withoutTrailingNewline(tok.content))
@@ -121,7 +121,7 @@ function tokenHandlers(schema, tokens) {
       handlers[type] = (state, tok) => state.addNode(nodeType, attrs(spec, tok))
     } else if (spec.mark) {
       let markType = schema.marks[spec.mark]
-      if (noOpenClose(type)) {
+      if (noOpenClose(spec, type)) {
         handlers[type] = (state, tok) => {
           state.openMark(markType.create(attrs(spec, tok)))
           state.addText(withoutTrailingNewline(tok.content))
@@ -132,7 +132,7 @@ function tokenHandlers(schema, tokens) {
         handlers[type + "_close"] = state => state.closeMark(markType)
       }
     } else if (spec.ignore) {
-      if (noOpenClose(type)) {
+      if (noOpenClose(spec, type)) {
         handlers[type] = noOp
       } else {
         handlers[type + '_open'] = noOp
@@ -224,8 +224,8 @@ export const defaultMarkdownParser = new MarkdownParser(schema, markdownit("comm
   bullet_list: {block: "bullet_list"},
   ordered_list: {block: "ordered_list", getAttrs: tok => ({order: +tok.attrGet("start") || 1})},
   heading: {block: "heading", getAttrs: tok => ({level: +tok.tag.slice(1)})},
-  code_block: {block: "code_block"},
-  fence: {block: "code_block", getAttrs: tok => ({params: tok.info || ""})},
+  code_block: {block: "code_block", noOpenClose: true},
+  fence: {block: "code_block", getAttrs: tok => ({params: tok.info || ""}), noOpenClose: true},
   hr: {node: "horizontal_rule"},
   image: {node: "image", getAttrs: tok => ({
     src: tok.attrGet("src"),
@@ -240,5 +240,5 @@ export const defaultMarkdownParser = new MarkdownParser(schema, markdownit("comm
     href: tok.attrGet("href"),
     title: tok.attrGet("title") || null
   })},
-  code_inline: {mark: "code"}
+  code_inline: {mark: "code", noOpenClose: true}
 })


### PR DESCRIPTION
This allows extension into other libraries that may other
markdown tokens that are not opened or closed. For example, texmath.

See ProseMirror/prosemirror-markdown#43

Notes:
* This is backwards compatible
* I have not added any tests
* I added the property to the documentation

I am not sure how to update type definitions. Let me know if you would like to see any changes on the PR!