### PR TITLE
Does not escape # character if it's not followed by whitespace

### DIFF
--- a/src/to_markdown.js
+++ b/src/to_markdown.js
@@ -365,7 +365,7 @@ export class MarkdownSerializerState {
   // have special meaning only at the start of the line.
   esc(str, startOfLine) {
     str = str.replace(/[`*\\~\[\]]/g, "\\$&")
-    if (startOfLine) str = str.replace(/^[:#\-*+]/, "\\$&").replace(/^(\s*\d+)\./, "$1\\.")
+    if (startOfLine) str = str.replace(/^[:\-*+]|#\s/, "\\$&").replace(/^(\s*\d+)\./, "$1\\.")
     return str
   }
 

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -144,4 +144,12 @@ describe("markdown", () => {
 
   it("doesn't escape characters in code", () =>
      same("foo`*`", doc(p("foo", code("*")))))
+
+  it("doesn't escape hashtag if it is not followed by whitespace", () =>
+    serialize(doc(p("#tag")), "#tag")
+  )
+
+  it("escape hashtag if it is followed by whitespace", () =>
+    serialize(doc(p("# tag")), "\\# tag")
+  )
 })


### PR DESCRIPTION
The issue was that the escape function escaped hashtags even when it wasn't followed by whitespace. In that case the # should not be escaped since for ex. #myhashtag is not a header ( there has to be a whitespace according to the markdown spec ).
This caused an issue when doing markdown->prosemirror->markdown conversion #myhashtag became /#myhashtag, I think the conversion to and back should should not change anything.

Illustrations

Original markdown editor:
![original markdown](https://user-images.githubusercontent.com/67345012/107849555-5464a400-6dfc-11eb-94ab-8b13d643269c.png)
After WYSIWYG conversion:
![to prosemirror](https://user-images.githubusercontent.com/67345012/107849554-5464a400-6dfc-11eb-9e8f-b80f02d4ed6b.png)
Back to markdown:
![result markdown](https://user-images.githubusercontent.com/67345012/107849553-53cc0d80-6dfc-11eb-986c-48272d58332c.png)
 