### PR TITLE
Update method signature for getAttrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the tokens to create a ProseMirror document tree.
      : Attributes for the node or mark. When `getAttrs` is provided,
        it takes precedence.
 
-   **`getAttrs`**`: ?(MarkdownToken) → Object`
+   **`getAttrs`**`: ?(MarkdownToken, tokens: Object, i: number) → Object`
      : A function used to compute the attributes for the node or mark
        that takes a [markdown-it
        token](https://markdown-it.github.io/markdown-it/#Token) and

--- a/src/from_markdown.js
+++ b/src/from_markdown.js
@@ -186,7 +186,7 @@ export class MarkdownParser {
   //   : Attributes for the node or mark. When `getAttrs` is provided,
   //     it takes precedence.
   //
-  // **`getAttrs`**`: ?(MarkdownToken) → Object`
+  // **`getAttrs`**`: ?(MarkdownToken, Object, number) → Object`
   //   : A function used to compute the attributes for the node or mark
   //     that takes a [markdown-it
   //     token](https://markdown-it.github.io/markdown-it/#Token) and


### PR DESCRIPTION
Per the code usage, the `getAttrs()` method actually accepts 3 arguments. Without the correct method signature, typescript complains about the usage.

There is a similar PR created to update the typescript `@types` definition for this package: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52752