### PR TITLE
export defaultMarkdownTokens() function

### DIFF
--- a/src/from_markdown.js
+++ b/src/from_markdown.js
@@ -231,31 +231,37 @@ function listIsTight(tokens, i) {
 // :: MarkdownParser
 // A parser parsing unextended [CommonMark](http://commonmark.org/),
 // without inline HTML, and producing a document in the basic schema.
-export const defaultMarkdownParser = new MarkdownParser(schema, markdownit("commonmark", {html: false}), {
-  blockquote: {block: "blockquote"},
-  paragraph: {block: "paragraph"},
-  list_item: {block: "list_item"},
-  bullet_list: {block: "bullet_list", getAttrs: (_, tokens, i) => ({tight: listIsTight(tokens, i)})},
-  ordered_list: {block: "ordered_list", getAttrs: (tok, tokens, i) => ({
-    order: +tok.attrGet("start") || 1,
-    tight: listIsTight(tokens, i)
-  })},
-  heading: {block: "heading", getAttrs: tok => ({level: +tok.tag.slice(1)})},
-  code_block: {block: "code_block", noCloseToken: true},
-  fence: {block: "code_block", getAttrs: tok => ({params: tok.info || ""}), noCloseToken: true},
-  hr: {node: "horizontal_rule"},
-  image: {node: "image", getAttrs: tok => ({
-    src: tok.attrGet("src"),
-    title: tok.attrGet("title") || null,
-    alt: tok.children[0] && tok.children[0].content || null
-  })},
-  hardbreak: {node: "hard_break"},
+export const defaultMarkdownParser = new MarkdownParser(schema, markdownit("commonmark", {html: false}), defaultMarkdownTokens())
 
-  em: {mark: "em"},
-  strong: {mark: "strong"},
-  link: {mark: "link", getAttrs: tok => ({
-    href: tok.attrGet("href"),
-    title: tok.attrGet("title") || null
-  })},
-  code_inline: {mark: "code", noCloseToken: true}
-})
+// :: MarkdownParser
+// The tokens used for the defaultMarkdownParser
+export function defaultMarkdownTokens() {
+  return {
+    blockquote: {block: "blockquote"},
+    paragraph: {block: "paragraph"},
+    list_item: {block: "list_item"},
+    bullet_list: {block: "bullet_list", getAttrs: (_, tokens, i) => ({tight: listIsTight(tokens, i)})},
+    ordered_list: {block: "ordered_list", getAttrs: (tok, tokens, i) => ({
+        order: +tok.attrGet("start") || 1,
+        tight: listIsTight(tokens, i)
+      })},
+    heading: {block: "heading", getAttrs: tok => ({level: +tok.tag.slice(1)})},
+    code_block: {block: "code_block", noCloseToken: true},
+    fence: {block: "code_block", getAttrs: tok => ({params: tok.info || ""}), noCloseToken: true},
+    hr: {node: "horizontal_rule"},
+    image: {node: "image", getAttrs: tok => ({
+        src: tok.attrGet("src"),
+        title: tok.attrGet("title") || null,
+        alt: tok.children[0] && tok.children[0].content || null
+      })},
+    hardbreak: {node: "hard_break"},
+
+    em: {mark: "em"},
+    strong: {mark: "strong"},
+    link: {mark: "link", getAttrs: tok => ({
+        href: tok.attrGet("href"),
+        title: tok.attrGet("title") || null
+      })},
+    code_inline: {mark: "code", noCloseToken: true}
+  }
+}

--- a/src/from_markdown.js
+++ b/src/from_markdown.js
@@ -242,26 +242,26 @@ export function defaultMarkdownTokens() {
     list_item: {block: "list_item"},
     bullet_list: {block: "bullet_list", getAttrs: (_, tokens, i) => ({tight: listIsTight(tokens, i)})},
     ordered_list: {block: "ordered_list", getAttrs: (tok, tokens, i) => ({
-        order: +tok.attrGet("start") || 1,
-        tight: listIsTight(tokens, i)
-      })},
+      order: +tok.attrGet("start") || 1,
+      tight: listIsTight(tokens, i)
+    })},
     heading: {block: "heading", getAttrs: tok => ({level: +tok.tag.slice(1)})},
     code_block: {block: "code_block", noCloseToken: true},
     fence: {block: "code_block", getAttrs: tok => ({params: tok.info || ""}), noCloseToken: true},
     hr: {node: "horizontal_rule"},
     image: {node: "image", getAttrs: tok => ({
-        src: tok.attrGet("src"),
-        title: tok.attrGet("title") || null,
-        alt: tok.children[0] && tok.children[0].content || null
-      })},
+      src: tok.attrGet("src"),
+      title: tok.attrGet("title") || null,
+      alt: tok.children[0] && tok.children[0].content || null
+    })},
     hardbreak: {node: "hard_break"},
 
     em: {mark: "em"},
     strong: {mark: "strong"},
     link: {mark: "link", getAttrs: tok => ({
-        href: tok.attrGet("href"),
-        title: tok.attrGet("title") || null
-      })},
+      href: tok.attrGet("href"),
+      title: tok.attrGet("title") || null
+    })},
     code_inline: {mark: "code", noCloseToken: true}
   }
 }


### PR DESCRIPTION
Thanks for the amazing ProseMirror ❤️ 

I'm extending the Markdown parser to add support for some additional Markdown tokens. I want to use the default token definitions, and add some more:

```typescript
const tokens = defaultMarkdownTokens()
tokens['table'] = {block: 'table'}
const parser = new MarkdownParser(schema, new MarkdownIt(), tokens)
```

By exposing `defaultMarkdownTokens` I can extend the default tokens without copy-pasting the entire tokens object. 