### PR TITLE
Upgrade markdown-it to v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "url": "git://github.com/prosemirror/prosemirror-markdown.git"
   },
   "dependencies": {
-    "prosemirror-model": "^1.0.0",
-    "markdown-it": "^10.0.0"
+    "markdown-it": "^12.0.0",
+    "prosemirror-model": "^1.0.0"
   },
   "devDependencies": {
     "ist": "1.0.0",


### PR DESCRIPTION
All tests passed successfully.

[Changelog v10 -> v11](https://github.com/markdown-it/markdown-it/blob/master/CHANGELOG.md#1100---2020-05-20)

[Changelog v11 -> v12](https://github.com/markdown-it/markdown-it/blob/master/CHANGELOG.md#1200---2020-10-14)

Made only 1 significant change in api:

> Added 3rd argument to highlight(code, lang, attrs), #626.

But this method is not used in the `prosemirror-markdown`.

