### PR TITLE
add serializer option to set custom regexp for escaping

### DIFF
--- a/src/to_markdown.js
+++ b/src/to_markdown.js
@@ -159,6 +159,11 @@ export class MarkdownSerializerState {
     //   Whether to render lists in a tight style. This can be overridden
     //   on a node level by specifying a tight attribute on the node.
     //   Defaults to false.
+    //
+    //   escCustomRegexp:: ?RegExp
+    //   Custom RegExp object is used for escaping text.
+    //   The regexp object is passed directly to String.replace(),
+    //   and the matching character is preceded by a backslash.
     this.options = options || {}
     if (typeof this.options.tightLists == "undefined")
       this.options.tightLists = false
@@ -369,6 +374,7 @@ export class MarkdownSerializerState {
       (m, i) => m == "_" && i > 0 && i + 1 < str.length && str[i-1].match(/\w/) && str[i+1].match(/\w/) ?  m : "\\" + m
     )
     if (startOfLine) str = str.replace(/^[:#\-*+>]/, "\\$&").replace(/^(\s*\d+)\./, "$1\\.")
+    if (this.options.escCustomRegexp) str = str.replace(this.options.escCustomRegexp, "\\$&")
     return str
   }
 

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -9,13 +9,13 @@ function parse(text, doc) {
   ist(defaultMarkdownParser.parse(text), doc, eq)
 }
 
-function serialize(doc, text) {
-  ist(defaultMarkdownSerializer.serialize(doc), text)
+function serialize(doc, text, options = {}) {
+  ist(defaultMarkdownSerializer.serialize(doc, options), text)
 }
 
-function same(text, doc) {
+function same(text, doc, options = {}) {
   parse(text, doc)
-  serialize(doc, text)
+  serialize(doc, text, options)
 }
 
 describe("markdown", () => {
@@ -182,4 +182,8 @@ describe("markdown", () => {
        doc(p("/_abc_)"))
      )
    )
+
+  it("escapes extra characters from options", () => {
+    same("foo\\|bar\\!", doc(p("foo|bar!")), { escCustomRegexp: /[\|!]/g })
+  })
 })


### PR DESCRIPTION
implemented in: https://discuss.prosemirror.net/t/escaping-custom-mark-when-entered-as-text/2654