### PR TITLE
Ensure the URL part of links is not escaped

### DIFF
--- a/src/to_markdown.ts
+++ b/src/to_markdown.ts
@@ -112,18 +112,21 @@ export const defaultMarkdownSerializer = new MarkdownSerializer({
       }
   },
   text(state, node) {
-    state.text(node.text!)
+    state.text(node.text!, !state.isAutolink)
   }
 }, {
   em: {open: "*", close: "*", mixable: true, expelEnclosingWhitespace: true},
   strong: {open: "**", close: "**", mixable: true, expelEnclosingWhitespace: true},
   link: {
     open(_state, mark, parent, index) {
-      return isPlainURL(mark, parent, index, 1) ? "<" : "["
+      _state.isAutolink = isPlainURL(mark, parent, index, 1)
+      return _state.isAutolink ? "<" : "["
     },
     close(_state, mark, parent, index) {
-      return isPlainURL(mark, parent, index, -1) ? ">"
+      const cont = _state.isAutolink ? ">"
         : "](" + mark.attrs.href + (mark.attrs.title ? ' "' + mark.attrs.title.replace(/"/g, '\\"') + '"' : "") + ")"
+      _state.isAutolink = undefined
+      return cont
     }
   },
   code: {open(_state, _mark, parent, index) { return backticksFor(parent.child(index), -1) },
@@ -159,6 +162,8 @@ export class MarkdownSerializerState {
   out: string = ""
   /// @internal
   closed: Node | null = null
+  /// @intermal
+  isAutolink?: boolean = undefined
   /// @internal
   inTightList: boolean = false
 

--- a/test/test-parse.ts
+++ b/test/test-parse.ts
@@ -150,39 +150,55 @@ describe("markdown", () => {
   })
 
   it("doesn't put a code block after a list item inside the list item", () =>
-     same("* list item\n\n```\ncode\n```",
-          doc(ul({tight: true}, li(p("list item"))), pre("code"))))
+    same("* list item\n\n```\ncode\n```",
+         doc(ul({tight: true}, li(p("list item"))), pre("code")))
+  )
 
   it("doesn't escape characters in code", () =>
-     same("foo`*`", doc(p("foo", code("*")))))
+    same("foo`*`", doc(p("foo", code("*"))))
+  )
 
   it("doesn't escape underscores between word characters", () =>
-     same(
-       "abc_def",
-       doc(p("abc_def"))
-     )
+    same(
+      "abc_def",
+      doc(p("abc_def"))
+    )
    )
 
-   it("doesn't escape strips of underscores between word characters", () =>
-     same(
-       "abc___def",
-       doc(p("abc___def"))
-     )
-   )
+  it("doesn't escape strips of underscores between word characters", () =>
+    same(
+      "abc___def",
+      doc(p("abc___def"))
+    )
+  )
 
-   it("escapes underscores at word boundaries", () =>
-     same(
-       "\\_abc\\_",
-       doc(p("_abc_"))
-     )
-   )
+  it("escapes underscores at word boundaries", () =>
+    same(
+      "\\_abc\\_",
+      doc(p("_abc_"))
+    )
+  )
 
-   it("escapes underscores surrounded by non-word characters", () =>
-     same(
-       "/\\_abc\\_)",
-       doc(p("/_abc_)"))
-     )
-   )
+  it("escapes underscores surrounded by non-word characters", () =>
+    same(
+      "/\\_abc\\_)",
+      doc(p("/_abc_)"))
+    )
+  )
+
+  it("ensure no escapes in url", () =>
+    parse(
+      "[text](https://example.com/_file/#~anchor)",
+      doc(p(a({href: "https://example.com/_file/#~anchor"}, "text")))
+    )
+  )
+
+  it("ensure no escapes in autolinks", () =>
+    same(
+      "<https://example.com/_file/#~anchor>",
+      doc(p(a({href: "https://example.com/_file/#~anchor"}, "https://example.com/_file/#~anchor")))
+    )
+  )
 
   it("escapes extra characters from options", () => {
     let markdownSerializer = new MarkdownSerializer(defaultMarkdownSerializer.nodes,


### PR DESCRIPTION
This resolves https://github.com/ProseMirror/prosemirror-markdown/issues/65

When doing the markdown serialization ensure that the URL part of links is not escaped as backslash escapes are not allowed within autolinks and the URL part of "normal" links (as of common mark).

This prevents invalid URLs after serialization if Autolinks containing `_` or `~` are used (every other special markdown symbol should be URL encoded anyways for URLs).

Added also some tests to ensure this behavior.