### PR TITLE
Escape ! in front of a link mark, fixes #73

### DIFF
--- a/src/to_markdown.ts
+++ b/src/to_markdown.ts
@@ -330,6 +330,9 @@ export class MarkdownSerializerState {
         while (active.length < len) {
           let add = marks[active.length]
           active.push(add)
+          // Special case link marks, escape a ! in front of it to prevent misinterpreting later as image
+          if (add.type.name === "link" && this.out.slice(-1) === "!" && this.out.slice(-2) !== "\\")
+            this.out = this.out.slice(0, this.out.length - 1) + '\\!'
           this.text(this.markString(add, true, parent, index), false)
         }
 

--- a/test/test-parse.ts
+++ b/test/test-parse.ts
@@ -150,32 +150,37 @@ describe("markdown", () => {
   })
 
   it("doesn't put a code block after a list item inside the list item", () =>
-     same("* list item\n\n```\ncode\n```",
-          doc(ul({tight: true}, li(p("list item"))), pre("code"))))
+    same("* list item\n\n```\ncode\n```",
+        doc(ul({tight: true}, li(p("list item"))), pre("code"))))
 
   it("doesn't escape characters in code", () =>
-     same("foo`*`", doc(p("foo", code("*")))))
+    same("foo`*`", doc(p("foo", code("*")))))
 
   it("doesn't escape underscores between word characters", () =>
-     same("abc_def", doc(p("abc_def"))))
+    same("abc_def", doc(p("abc_def"))))
 
-   it("doesn't escape strips of underscores between word characters", () =>
-     same("abc___def", doc(p("abc___def"))))
+  it("doesn't escape strips of underscores between word characters", () =>
+    same("abc___def", doc(p("abc___def"))))
 
-   it("escapes underscores at word boundaries", () =>
-     same("\\_abc\\_", doc(p("_abc_"))))
+  it("escapes underscores at word boundaries", () =>
+    same("\\_abc\\_", doc(p("_abc_"))))
 
-   it("escapes underscores surrounded by non-word characters", () =>
-     same("/\\_abc\\_)", doc(p("/_abc_)"))))
+  it("escapes underscores surrounded by non-word characters", () =>
+    same("/\\_abc\\_)", doc(p("/_abc_)"))))
 
   it("ensure no escapes in url", () =>
     parse("[text](https://example.com/_file/#~anchor)",
           doc(p(a({href: "https://example.com/_file/#~anchor"}, "text")))))
 
+  // From issue #65
   it("ensure no escapes in autolinks", () =>
     same("<https://example.com/_file/#~anchor>",
          doc(p(a({href: "https://example.com/_file/#~anchor"}, "https://example.com/_file/#~anchor"))))
   )
+
+  // From issue #73
+  it("escape ! in front of links", () =>
+    serialize(doc(p("!", a("text"))), "\\![text](foo)"))
 
   it("escapes extra characters from options", () => {
     let markdownSerializer = new MarkdownSerializer(defaultMarkdownSerializer.nodes,


### PR DESCRIPTION
Ensure `!` character is escaped if used in front of a link mark
to prevent misinterpreting it as a image node.

Also added a test for this behavior and did some minor test
cleanup (unify indention).

Not sure if this is the cleanest solution but it works.