### PR TITLE
Fix escaping of parentheses in links and images

### DIFF
--- a/src/to_markdown.ts
+++ b/src/to_markdown.ts
@@ -101,7 +101,7 @@ export const defaultMarkdownSerializer = new MarkdownSerializer({
   },
 
   image(state, node) {
-    state.write("![" + state.esc(node.attrs.alt || "") + "](" + node.attrs.src +
+    state.write("![" + state.esc(node.attrs.alt || "") + "](" + node.attrs.src.replace(/[\(\)]/g, "\\$&") +
                 (node.attrs.title ? ' "' + node.attrs.title.replace(/"/g, '\\"') + '"' : "") + ")")
   },
   hard_break(state, node, parent, index) {
@@ -126,7 +126,7 @@ export const defaultMarkdownSerializer = new MarkdownSerializer({
       let {inAutolink} = state
       state.inAutolink = undefined
       return inAutolink ? ">"
-        : "](" + mark.attrs.href + (mark.attrs.title ? ' "' + mark.attrs.title.replace(/"/g, '\\"') + '"' : "") + ")"
+        : "](" + mark.attrs.href.replace(/[\(\)"]/g, "\\$&") + (mark.attrs.title ? ` "${mark.attrs.title.replace(/"/g, '\\"')}"` : "") + ")"
     }
   },
   code: {open(_state, _mark, parent, index) { return backticksFor(parent.child(index), -1) },

--- a/test/test-parse.ts
+++ b/test/test-parse.ts
@@ -181,12 +181,21 @@ describe("markdown", () => {
   it("escape ! in front of links", () =>
     serialize(doc(p("!", a("text"))), "\\![text](foo)"))
 
+  // Issue #78
+  it("escape of URL in links and images", () => {
+    serialize(doc(p(a({href: "foo):"}, "link"))), "[link](foo\\):)")
+    serialize(doc(p(a({href: "(foo"}, "link"))), "[link](\\(foo)")
+    serialize(doc(p(img({src: "foo):"}))), "![x](foo\\):)")
+    serialize(doc(p(img({src: "(foo"}))), "![x](\\(foo)")
+    serialize(doc(p(a({title: "bar", href: "foo%20\""}, "link"))), "[link](foo%20\\\" \"bar\")")
+  })
+
   it("escapes extra characters from options", () => {
     let markdownSerializer = new MarkdownSerializer(defaultMarkdownSerializer.nodes,
                                                     defaultMarkdownSerializer.marks,
                                                     {escapeExtraCharacters: /[\|!]/g})
     ist(markdownSerializer.serialize(doc(p("foo|bar!"))), "foo\\|bar\\!")
- })
+  })
 
   it("escapes list markers inside lists", () => {
     same("* 1\\. hi\n\n* x", doc(ul(li(p("1. hi")), li(p("x")))))


### PR DESCRIPTION
* Resolves: #78

If the URL contains a `)` character the link is currently not correctly serialized.