### PR TITLE
Only add newline after hard line break if needed

### DIFF
--- a/src/to_markdown.ts
+++ b/src/to_markdown.ts
@@ -107,7 +107,9 @@ export const defaultMarkdownSerializer = new MarkdownSerializer({
   hard_break(state, node, parent, index) {
     for (let i = index + 1; i < parent.childCount; i++)
       if (parent.child(i).type != node.type) {
-        state.write("\\\n")
+        // Only write newline if there is not already one
+        if (parent.child(i).text?.startsWith('\n')) state.write("\\")
+        else state.write("\\\n")
         return
       }
   },

--- a/test/test-parse.ts
+++ b/test/test-parse.ts
@@ -195,6 +195,12 @@ describe("markdown", () => {
     serialize(doc(p(a({title: "bar", href: "foo%20\""}, "link"))), "[link](foo%20\\\" \"bar\")")
   })
 
+  // Issue #80
+  it("hard line breaks followed by newline", () => {
+    serialize(doc(p(em("foo", br(), "\nbar"))), "*foo\\\nbar*")
+    serialize(doc(p(em("foo", br(), "bar"))), "*foo\\\nbar*")
+  })
+
   it("escapes extra characters from options", () => {
     let markdownSerializer = new MarkdownSerializer(defaultMarkdownSerializer.nodes,
                                                     defaultMarkdownSerializer.marks,


### PR DESCRIPTION
* Resolves: #80

If `preserveWhitespace: 'full'` is set, hard line breaks are
parsed as `<br \>\n` so the newline character after the tag is not removed.
In this case there must be no additional newline character added when
serializing the `<br \>` tag to markdown as this would create a new block and break marks.