### PR TITLE
allow empty string as firstDelim

### DIFF
--- a/src/to_markdown.ts
+++ b/src/to_markdown.ts
@@ -202,7 +202,7 @@ export class MarkdownSerializerState {
   /// content of the block.
   wrapBlock(delim: string, firstDelim: string | null, node: Node, f: () => void) {
     let old = this.delim
-    this.write(firstDelim || delim)
+    this.write(firstDelim != null ? firstDelim : delim)
     this.delim += delim
     f()
     this.delim = old


### PR DESCRIPTION
Hey! 

Thanks for all the great work you put into Prosemirror! 

We recently used prosemirror-markdown to transform our JSON content to Markdown. While doing that, we had the case that we wanted to render a list in which all items except the first had a delimiter. 

This wasn't possible since passing in an empty string as `firstDelim` was considered falsy in `firstDelim || delim`.

I would like to propose changing it to `firstDelim != null ? firstDelim : delim` so that delim really only gets used if firstDelim is null or undefned.