### PR TITLE
Check content of code blocks for any sequence of backticks

### DIFF
--- a/src/to_markdown.ts
+++ b/src/to_markdown.ts
@@ -65,10 +65,14 @@ export const defaultMarkdownSerializer = new MarkdownSerializer({
     state.wrapBlock("> ", null, node, () => state.renderContent(node))
   },
   code_block(state, node) {
-    state.write("```" + (node.attrs.params || "") + "\n")
+    // Make sure the front matter fences are longer than any dash sequence within it
+    const backticks = node.textContent.match(/`{3,}/gm)
+    const fence = backticks ? (backticks.sort().slice(-1)[0] + "`") : "```"
+
+    state.write(fence + (node.attrs.params || "") + "\n")
     state.text(node.textContent, false)
     state.ensureNewLine()
-    state.write("```")
+    state.write(fence)
     state.closeBlock(node)
   },
   heading(state, node) {

--- a/test/test-parse.ts
+++ b/test/test-parse.ts
@@ -209,4 +209,9 @@ describe("markdown", () => {
   it("escapes list markers inside lists", () => {
     same("* 1\\. hi\n\n* x", doc(ul(li(p("1. hi")), li(p("x")))))
   })
+
+  // Issue #88
+  it("code block fence adjusts to content", () => {
+    same("````\n```\ncode\n```\n````", doc(pre("```\ncode\n```")))
+  })
 })


### PR DESCRIPTION
* Resolves: #88

---

CommonMark allows a sequence of backticks within a code block, but the fence has to be at least one backtick longer than the sequence within. See the linked issue for a detailed explanation.