### PR TITLE
fix: always adding new line in code block

### DIFF
--- a/src/to_markdown.ts
+++ b/src/to_markdown.ts
@@ -71,7 +71,8 @@ export const defaultMarkdownSerializer = new MarkdownSerializer({
 
     state.write(fence + (node.attrs.params || "") + "\n")
     state.text(node.textContent, false)
-    state.ensureNewLine()
+    // Add a newline to the current content before adding closing marker 
+    state.write("\n")
     state.write(fence)
     state.closeBlock(node)
   },

--- a/test/test-parse.ts
+++ b/test/test-parse.ts
@@ -214,4 +214,10 @@ describe("markdown", () => {
   it("code block fence adjusts to content", () => {
     same("````\n```\ncode\n```\n````", doc(pre("```\ncode\n```")))
   })
+
+  it("parses a code block ends with empty line", () => {
+    const originalText = "1\n"
+    const mdText = defaultMarkdownSerializer.serialize(doc(schema.node("code_block", {params: ""}, [schema.text(originalText)])))
+    same(mdText, doc(schema.node("code_block", {params: ""}, [schema.text(originalText)])))
+  })
 })


### PR DESCRIPTION
If a code block ends with an empty line, a new line will not be added to the state
https://github.com/ProseMirror/prosemirror-markdown/blob/master/src/to_markdown.ts#L74

But when parsing markdown, the new line will be removed
https://github.com/ProseMirror/prosemirror-markdown/blob/master/src/from_markdown.ts#L116

This causes the issue that content before and after parsing will be different

Example:
```
Line 1

```

**Current version**
```
Line 1
```

**After new change**
```
Line 1

```