### PR TITLE
Added reference to MarkdownIt typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
     "prosemirror-model": "^1.0.0"
   },
   "devDependencies": {
-    "punycode": "^1.4.0",
     "@prosemirror/buildhelper": "^0.1.5",
-    "prosemirror-test-builder": "^1.0.0"
+    "@types/markdown-it": "^12.2.3",
+    "prosemirror-test-builder": "^1.0.0",
+    "punycode": "^1.4.0"
   },
   "scripts": {
     "test": "pm-runtests",

--- a/src/from_markdown.ts
+++ b/src/from_markdown.ts
@@ -145,7 +145,7 @@ function tokenHandlers(schema: Schema, tokens: {[token: string]: ParseSpec}) {
   }
 
   handlers.text = (state, tok) => state.addText(tok.content)
-  handlers.inline = (state, tok) => state.parseTokens(tok.children || [])
+  handlers.inline = (state, tok) => state.parseTokens(tok.children!)
   handlers.softbreak = handlers.softbreak || (state => state.addText(" "))
 
   return handlers
@@ -258,7 +258,7 @@ export const defaultMarkdownParser = new MarkdownParser(schema, MarkdownIt("comm
   image: {node: "image", getAttrs: tok => ({
     src: tok.attrGet("src"),
     title: tok.attrGet("title") || null,
-    alt: tok.children && tok.children[0] && tok.children[0].content || null
+    alt: tok.children![0] && tok.children![0].content || null
   })},
   hardbreak: {node: "hard_break"},
 


### PR DESCRIPTION
Added a reference to `@types/markdown-it` from DefinitelyTyped, replacing the types marked as FIXME and slightly adapting references to `Token.children` to account for its nullability.