### PR TITLE
Don't escape number signs (#) if they won't be parsed as headings

### DIFF
--- a/src/to_markdown.ts
+++ b/src/to_markdown.ts
@@ -402,7 +402,7 @@ export class MarkdownSerializerState {
       /[`*\\~\[\]_]/g,
       (m, i) => m == "_" && i > 0 && i + 1 < str.length && str[i-1].match(/\w/) && str[i+1].match(/\w/) ?  m : "\\" + m
     )
-    if (startOfLine) str = str.replace(/^[#\-*+>]/, "\\$&").replace(/^(\s*\d+)\.\s/, "$1\\. ")
+    if (startOfLine) str = str.replace(/^[\-*+>]/, "\\$&").replace(/^(\s*)(#{1,6})(\s|$)/, '$1\\$2$3').replace(/^(\s*\d+)\.\s/, "$1\\. ")
     if (this.options.escapeExtraCharacters) str = str.replace(this.options.escapeExtraCharacters, "\\$&")
     return str
   }

--- a/test/test-parse.ts
+++ b/test/test-parse.ts
@@ -219,6 +219,27 @@ describe("markdown", () => {
     same("1.2kg", doc(p("1.2kg")))
   })
 
+  // Issue #105
+  it("escapes ATX heading markers with space after them", () => {
+    same("\\### text", doc(p("### text")))
+  })
+
+  it("escapes ATX heading markers followed by the end of line", () => {
+    same("\\###", doc(p("###")))
+  })
+
+  it("does not escape ATX heading markers without space after them", () => {
+    same("#hashtag", doc(p("#hashtag")))
+  })
+
+  it("does not escape ATX heading markers consisting of more than 6 in a sequence", () => {
+    same("#######", doc(p("#######")))
+  })
+
+  it("keeps Unicode space after ATX heading markers when escaping", () => {
+    same("\\#　こんにちは", doc(p("#　こんにちは")))
+  })
+
   // Issue #88
   it("code block fence adjusts to content", () => {
     same("````\n```\ncode\n```\n````", doc(pre("```\ncode\n```")))


### PR DESCRIPTION
Fixes #105 and add related test patterns

Note: Although [CommonMark 0.30](https://spec.commonmark.org/0.30/#atx-headings) only specifies *spaces, tabs, or by the end of line* as the separator between the heading markers `#` and the heading content, my code uses `\s` regex to identify spaces (like the code for escaping list item markers), so it will escape heading markers if they are followed by a Unicode space.

It's stricter but has better compatibility with other Markdown editors, e.g. iA Writer parses `#　123456` (with `U+3000` in between) as a heading.