### PR TITLE
Escape "+" character at the start of text line (bullet list marker)

### DIFF
--- a/src/to_markdown.ts
+++ b/src/to_markdown.ts
@@ -410,7 +410,7 @@ export class MarkdownSerializerState {
       /[`*\\~\[\]_]/g,
       (m, i) => m == "_" && i > 0 && i + 1 < str.length && str[i-1].match(/\w/) && str[i+1].match(/\w/) ?  m : "\\" + m
     )
-    if (startOfLine) str = str.replace(/^(\+[ ]|[\-*>])/, "\\$&").replace(/^(\s*)(#{1,6})(\s|$)/, '$1\\$2$3').replace(/^(\s*\d+)\.\s/, "$1\\. ")
+    if (startOfLine) str = str.replace(/^(\+[ ]|[\-*+>])/, "\\$&").replace(/^(\s*)(#{1,6})(\s|$)/, '$1\\$2$3').replace(/^(\s*\d+)\.\s/, "$1\\. ")
     if (this.options.escapeExtraCharacters) str = str.replace(this.options.escapeExtraCharacters, "\\$&")
     return str
   }


### PR DESCRIPTION
As per [CommonMark spec](https://spec.commonmark.org/0.31.2/#bullet-list-marker), "+" is considered as a bullet list marker thus sould be escaped at the start of line.

This have been detected in https://github.com/aguingand/tiptap-markdown/issues/65.
