### PR TITLE
fix `parse` type to always return Node

### DIFF
--- a/src/from_markdown.ts
+++ b/src/from_markdown.ts
@@ -230,7 +230,7 @@ export class MarkdownParser {
     let state = new MarkdownParseState(this.schema, this.tokenHandlers), doc
     state.parseTokens(this.tokenizer.parse(text, markdownEnv))
     do { doc = state.closeNode() } while (state.stack.length)
-    return doc || this.schema.topNodeType.createAndFill()
+    return doc || this.schema.topNodeType.createAndFill()!
   }
 }
 


### PR DESCRIPTION
The type for `parse` is currently

```ts
    parse(text: string, markdownEnv?: Object): Node | null;
```

because it uses `Node.createAndFill()`. But because `content` is always null, we can assume `createAndFill()` always returns a `Node`.

https://github.com/ProseMirror/prosemirror-model/blob/b71f73f193b15ab1661451636352905b06a6fb0d/src/schema.ts#L157-L169 