### PR TITLE
render missing nodes

### DIFF
--- a/src/to_markdown.ts
+++ b/src/to_markdown.ts
@@ -260,8 +260,17 @@ export class MarkdownSerializerState {
 
   /// Render the given node as a block.
   render(node: Node, parent: Node, index: number) {
-    if (!this.nodes[node.type.name]) throw new Error("Token type `" + node.type.name + "` not supported by Markdown renderer")
-    this.nodes[node.type.name](this, node, parent, index)
+    let render = this.nodes[node.type.name];
+    if (render) {
+      render(this, node, parent, index);
+    } else {
+      if (node.type.inlineContent) {
+        this.renderInline(node)
+        this.closeBlock(node)
+      } else {
+        this.renderContent(node)
+      }
+    }
   }
 
   /// Render the contents of `parent` as block nodes.

--- a/src/to_markdown.ts
+++ b/src/to_markdown.ts
@@ -260,16 +260,14 @@ export class MarkdownSerializerState {
 
   /// Render the given node as a block.
   render(node: Node, parent: Node, index: number) {
-    let render = this.nodes[node.type.name];
-    if (render) {
-      render(this, node, parent, index);
+    let render = this.nodes[node.type.name]
+    if (render) return render(this, node, parent, index)
+    if (node.type.isLeaf) return
+    if (node.type.inlineContent) {
+      this.renderInline(node)
+      this.closeBlock(node)
     } else {
-      if (node.type.inlineContent) {
-        this.renderInline(node)
-        this.closeBlock(node)
-      } else {
-        this.renderContent(node)
-      }
+      this.renderContent(node)
     }
   }
 


### PR DESCRIPTION
I have some custom nodes that don't have a good markdown equivalent.

Instead of throwing an error that node is unsupported, I think for good defaults we can have
- leaf: no-op
- inlineContent: renderInline as if it's a paragraph
- else: renderContent